### PR TITLE
(QENG-5244) Add cloudformation templates

### DIFF
--- a/lambdas/ec2/deploy_reaper.yaml
+++ b/lambdas/ec2/deploy_reaper.yaml
@@ -1,0 +1,189 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Parameters:
+  TerminatorRate:
+    Type: String
+    Default: rate(1 hour)
+    Description: The rate at which to check for expired instances
+
+  HIPCHATTOKEN:
+    Type: String
+    Description: Token to use when posting notifications to Hipchat
+
+  HIPCHATROOMID:
+    Type: String
+    Description: Which Hipchat room to post to
+
+  LIVEMODE:
+    Type: String
+    Default: "False"
+    Description: Toggle for if the reaper actually deletes ec2 instances.
+
+  S3BucketPrefix:
+    Type: String
+    Default: ec2-reaper
+    Description: Prefix for the S3 Bucket with resources created by the deploy_to_s3 job.
+
+Resources:
+  ReaperRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          -
+            Effect: "Allow"
+            Principal:
+              Service:
+                - 'lambda.amazonaws.com'
+            Action:
+                - "sts:AssumeRole"
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonEC2FullAccess
+        - arn:aws:iam::aws:policy/AWSLambdaFullAccess
+        - arn:aws:iam::aws:policy/IAMReadOnlyAccess
+        - arn:aws:iam::aws:policy/CloudWatchActionsEC2Access
+
+  LambdaTerminator:
+    Type: AWS::Lambda::Function
+    Properties:
+      Code:
+        S3Key: reaper.zip
+        S3Bucket: !Sub "${S3BucketPrefix}-${AWS::Region}"
+      Handler: reaper.terminate_expired_instances
+      Environment:
+        Variables:
+          LIVEMODE: !Ref LIVEMODE
+      Timeout: 300
+      Runtime: python2.7
+      Role: !GetAtt ReaperRole.Arn 
+    DependsOn: ReaperRole
+
+  LambdaTerminatorRule:
+    Type: AWS::Events::Rule
+    Properties:
+      Description: Rule for Terminator Lambda
+      ScheduleExpression: !Ref TerminatorRate
+      State: ENABLED
+      Targets: 
+        -
+          Arn: !GetAtt LambdaTerminator.Arn
+          Id: !Ref LambdaTerminator
+
+  LambdaTerminatorPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref LambdaTerminator
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt LambdaTerminatorRule.Arn
+
+  LambdaSchemaEnforcer:
+    Type: AWS::Lambda::Function
+    Properties:
+      Code:
+        S3Key: reaper.zip
+        S3Bucket: !Sub "${S3BucketPrefix}-${AWS::Region}"
+      Handler: reaper.enforce
+      Environment:
+        Variables:
+          LIVEMODE: !Ref LIVEMODE
+      Timeout: 300
+      Runtime: python2.7
+      Role: !GetAtt ReaperRole.Arn 
+    DependsOn: ReaperRole
+
+  LambdaSchemaEnforcerRule:
+    Type: AWS::Events::Rule
+    Properties:
+      Description: Rule for enforcer lambda
+      EventPattern:
+        source:
+          - aws.ec2
+        detail-type:
+          - EC2 Instance State-change Notification
+        detail:
+          state:
+            - pending
+      State: ENABLED
+      Targets: 
+        -
+          Arn: !GetAtt LambdaSchemaEnforcer.Arn
+          Id: !Ref LambdaSchemaEnforcer
+
+  LambdaSchemaEnforcerPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref LambdaSchemaEnforcer
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt LambdaSchemaEnforcerRule.Arn
+
+  LambdaTerminatorLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${LambdaTerminator}"
+      RetentionInDays: 7
+
+  LambdaSchemaEnforcerLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${LambdaSchemaEnforcer}"
+      RetentionInDays: 7
+
+  LambdaHipchatNotifierLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${LambdaHipchatNotifier}"
+      RetentionInDays: 7
+
+  LambdaHipchatNotifier:
+    Type: AWS::Lambda::Function
+    Properties:
+      Code:
+        S3Key: hipchat_notifier.zip
+        S3Bucket: !Sub "${S3BucketPrefix}-${AWS::Region}"
+      Handler: hipchat_notifier.post
+      Timeout: 300
+      Runtime: python2.7
+      Role: !GetAtt ReaperRole.Arn 
+      Environment:
+        Variables:
+          HIPCHATTOKEN: !Ref HIPCHATTOKEN
+          HIPCHATROOMID: !Ref HIPCHATROOMID
+    DependsOn: ReaperRole
+
+  SchemaEnforcerHipchatNotifierSubscription:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: !GetAtt LambdaHipchatNotifier.Arn
+      FilterPattern: REAPER TERMINATION
+      LogGroupName: !Ref LambdaSchemaEnforcerLogGroup
+    DependsOn: SchemaEnforcerHipchatNotifierPermission
+
+  TerminatorHipchatNotifierSubscription:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: !GetAtt LambdaHipchatNotifier.Arn
+      FilterPattern: REAPER TERMINATION
+      LogGroupName: !Ref LambdaTerminatorLogGroup
+    DependsOn: TerminatorHipchatNotifierPermission
+
+  TerminatorHipchatNotifierPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref LambdaHipchatNotifier
+      Principal: !Sub "logs.${AWS::Region}.amazonaws.com"
+      SourceArn: !Sub
+        - ${LogGroupArn}
+        - { LogGroupArn: !GetAtt LambdaTerminatorLogGroup.Arn }
+
+  SchemaEnforcerHipchatNotifierPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref LambdaHipchatNotifier
+      Principal: !Sub "logs.${AWS::Region}.amazonaws.com"
+      SourceArn: !Sub
+        - ${LogGroupArn}
+        - { LogGroupArn: !GetAtt LambdaSchemaEnforcerLogGroup.Arn }

--- a/lambdas/ec2/deploy_to_s3.yaml
+++ b/lambdas/ec2/deploy_to_s3.yaml
@@ -1,0 +1,156 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+
+Parameters:
+  OriginalS3Bucket:
+    Type: String
+    Default: reaperfiles
+    Description: Original bucket that the reaper script resides in.
+
+  OriginalReaperZip:
+    Type: String
+    Default: reaper.zip
+    Description: Key for the reaper.zip file in the S3 bucket.
+
+  OriginalHipchatNotifierZip:
+    Type: String
+    Default: hipchat_notifier.zip
+    Description: Key for the reaper.zip file in the S3 bucket.
+
+  S3BucketPrefix:
+    Type: String
+    Default: ec2-reaper
+    Description: Prefix for the S3 Bucket Name in each region.
+
+Resources:
+  S3CopierRole:
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          -
+            Action:
+              - "sts:AssumeRole"
+            Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+        Version: "2012-10-17"
+      Path: /
+      Policies:
+        -
+          PolicyDocument:
+            Statement:
+              -
+                Action:
+                  - "logs:CreateLogGroup"
+                  - "logs:CreateLogStream"
+                  - "logs:PutLogEvents"
+                Effect: Allow
+                Resource: "arn:aws:logs:*:*:*"
+              -
+                Action:
+                  - "s3:*"
+                Effect: Allow
+                Resource: "*"
+            Version: "2012-10-17"
+          PolicyName: root
+    Type: "AWS::IAM::Role"
+
+  S3Bucket:
+    Type: "AWS::S3::Bucket"
+    Properties:
+      BucketName: !Sub "${S3BucketPrefix}-${AWS::Region}"
+      AccessControl: PublicRead
+      
+  S3CopierLambda:
+    Properties:
+      Timeout: 180
+      Code:
+        ZipFile:
+          !Sub |
+            import boto3
+            import json
+            import sys
+            import traceback
+
+            try:
+                from urllib2 import HTTPError, build_opener, HTTPHandler, Request
+            except ImportError:
+                from urllib.error import HTTPError
+                from urllib.request import build_opener, HTTPHandler, Request
+
+            SUCCESS = "SUCCESS"
+            FAILED = "FAILED"
+            s3 = boto3.resource('s3')
+            def handler(event, context):
+                print event
+                try:
+                    if event['RequestType'] == 'Delete':
+                        print('Deletion request received')
+                        bucket = s3.Bucket(event['ResourceProperties']['NewBucket'])
+                        bucket.objects.all().delete()
+                        send(event, context, SUCCESS)
+                        return
+                    copy_source = {'Bucket': event['ResourceProperties']['OrigBucketName'],
+                        'Key': event['ResourceProperties']['OrigReaperKey']}
+                    s3.meta.client.copy(copy_source, 
+                        event['ResourceProperties']['NewBucket'],
+                        event['ResourceProperties']['OrigReaperKey'])
+                    s3.ObjectAcl(event['ResourceProperties']['NewBucket'],
+                        event['ResourceProperties']['OrigReaperKey']).put(ACL='public-read')
+                    hc_notifier_copy_source = {'Bucket': event['ResourceProperties']['OrigBucketName'],
+                        'Key': event['ResourceProperties']['OrigHipchatNotifierKey']}
+                    s3.meta.client.copy(hc_notifier_copy_source, 
+                        event['ResourceProperties']['NewBucket'],
+                        event['ResourceProperties']['OrigHipchatNotifierKey'])
+                    s3.ObjectAcl(event['ResourceProperties']['NewBucket'],
+                        event['ResourceProperties']['OrigHipchatNotifierKey']).put(ACL='public-read')
+                except Exception as e:
+                    print('Error copying S3 data')
+                    exc_type, exc_value, exc_traceback = sys.exc_info()
+                    traceback.print_exception(exc_type, exc_value, exc_traceback,
+                                              limit=2, file=sys.stdout)
+                    send(event, context, FAILED)
+                send(event, context, SUCCESS)
+
+            def send(event, context, response_status, reason=None, response_data=None, physical_resource_id=None):
+                response_data = response_data or {}
+                response_body = json.dumps(
+                    {
+                        'Status': response_status,
+                        'Reason': reason or "See the details in CloudWatch Log Stream: " + context.log_stream_name,
+                        'PhysicalResourceId': physical_resource_id or context.log_stream_name,
+                        'StackId': event['StackId'],
+                        'RequestId': event['RequestId'],
+                        'LogicalResourceId': event['LogicalResourceId'],
+                        'Data': response_data
+                    }
+                )
+
+                opener = build_opener(HTTPHandler)
+                request = Request(event['ResponseURL'], data=response_body)
+                request.add_header('Content-Type', '')
+                request.add_header('Content-Length', len(response_body))
+                request.get_method = lambda: 'PUT'
+                try:
+                    response = opener.open(request)
+                    print("Status code: {}".format(response.getcode()))
+                    print("Status message: {}".format(response.msg))
+                    return True
+                except HTTPError as exc:
+                    print("Failed executing HTTP request: {}".format(exc.code))
+                    return False 
+      Handler: index.handler
+      Role: !GetAtt S3CopierRole.Arn
+      Runtime: python2.7
+    Type: "AWS::Lambda::Function"
+
+  S3CopierLambdaTrigger:
+    Type: Custom::LambdaTrigger
+    Properties:
+      ServiceToken: !GetAtt S3CopierLambda.Arn
+      OrigBucketName: !Ref OriginalS3Bucket
+      OrigReaperKey: !Ref OriginalReaperZip
+      OrigHipchatNotifierKey: !Ref OriginalHipchatNotifierZip
+      NewBucket: !Ref S3Bucket
+

--- a/lambdas/ec2/hipchat_notifier.py
+++ b/lambdas/ec2/hipchat_notifier.py
@@ -27,13 +27,20 @@ def read_token():
     """
     Read in the environment HIPCHAT_TOKEN.
     """
-    return os.environ['HIPCHAT_TOKEN']
+    return os.environ['HIPCHATTOKEN']
 
 def read_room_id():
     """
     Read in the environment HIPCHAT_ROOM_ID.
     """
-    return int(os.environ['HIPCHAT_ROOM_ID'])
+    return int(os.environ['HIPCHATROOMID'])
+
+def determine_region():
+    """
+    Determine the current region execution
+    """
+    region = boto3.session.Session().region_name
+    return region
 
 def process_subscription_notification(event):
     """
@@ -82,7 +89,7 @@ def post(event, context):
     url = 'https://api.hipchat.com/v2/room/%d/notification' % ROOMID
 
     event_processed = process_subscription_notification(event)
-    
+
     for log_event in event_processed['logEvents']:
 
         message = log_event['message']
@@ -94,7 +101,7 @@ def post(event, context):
             'color': determine_hipchat_color(event_processed, message),
             'message_format': 'html',
             'notify': False,
-            'from': get_account_alias()})
+            'from': get_account_alias() + " " + determine_region()})
         request = Request(url, headers=headers, data=datastr)
         uopen = urlopen(request)
         rawresponse = ''.join(uopen)

--- a/lambdas/ec2/reaper.py
+++ b/lambdas/ec2/reaper.py
@@ -12,18 +12,18 @@ ec2 = boto3.resource('ec2')
 
 def determine_live_mode():
     """
-    Returns True if LIVE_MODE is set to true in the shell environment, False for
+    Returns True if LIVEMODE is set to true in the shell environment, False for
     all other cases.
     """
-    if 'LIVE_MODE' in os.environ:
-        return re.search(r'(?i)^true$', os.environ['LIVE_MODE']) is not None
+    if 'LIVEMODE' in os.environ:
+        return re.search(r'(?i)^true$', os.environ['LIVEMODE']) is not None
     else:
         return False
 
-# The `LIVE_MODE` environment variable controls if this script is actually
-# running and reaping in your AWS environment. To turn reaping on, set 
-# the `LIVE_MODE` environment variable to true in your Lambda environment.
-LIVE_MODE = determine_live_mode()
+# The `LIVEMODE` environment variable controls if this script is actually
+# running and reaping in your AWS environment. To turn reaping on, set
+# the `LIVEMODE` environment variable to true in your Lambda environment.
+LIVEMODE = determine_live_mode()
 
 # The `MINUTES_TO_WAIT` global variable is the number of minutes to wait for
 # a termination_date tag to appear for the EC2 instance. Please note that the
@@ -110,16 +110,16 @@ def terminate_instance(ec2_instance, message):
     :param ec2_instance: a boto3 resource representing an Amazon EC2 Instance.
     :param message: string explaining why the instance is being terminated.
 
-    Prints a message and terminates an instance if LIVE_MODE is True. Otherwise, print out
+    Prints a message and terminates an instance if LIVEMODE is True. Otherwise, print out
     the instance id of EC2 resource that would have been deleted.
     """
     output = "REAPER TERMINATION message(ec2_instance_id={0}): {1}\n".format(ec2_instance.id,message)
-    if LIVE_MODE:
+    if LIVEMODE:
         output += 'REAPER TERMINATION enabled: deleting instance {0}'.format(ec2_instance.id)
         print(output)
         ec2_instance.terminate()
     else:
-        output += "REAPER TERMINATION not enabled: LIVE_MODE is {0}. Would have deleted instance {1}".format(LIVE_MODE, ec2_instance.id)
+        output += "REAPER TERMINATION not enabled: LIVEMODE is {0}. Would have deleted instance {1}".format(LIVEMODE, ec2_instance.id)
         print(output)
 
 def validate_ec2_termination_date(ec2_instance):
@@ -242,9 +242,9 @@ def terminate_expired_instances(event, context):
             terminate_instance(instance, "EC2 instance is expired")
             deleted_instances.append(instance)
 
-    if LIVE_MODE:
+    if LIVEMODE:
         print("REAPER TERMINATION completed. The following instances have been deleted: {0}".format(deleted_instances))
     else:
-        print("REAPER TERMINATION completed. LIVE_MODE is off, would have deleted the following instances: {0}".format(deleted_instances))
+        print("REAPER TERMINATION completed. LIVEMODE is off, would have deleted the following instances: {0}".format(deleted_instances))
     if improperly_tagged:
         print("REAPER TERMINATION completed but bad tags found. Found unparsable or missing termination_date tags for: {0}".format(improperly_tagged))


### PR DESCRIPTION
This commit adds cloudformation templates for reaper deployment; prior
to this, deployment had to be manually done. Now the reaper can be
deployed from a single AWS account into multiple accounts and multiple
regions.

Besides changes to the README, the actual lambda code had to be adjusted
to determine which region it was reporting from, and changing the
environment variables per lambda because cloudformation does not allow
for the underscore character for environment variables.