### PR TITLE
New updates

### DIFF
--- a/lambdas/ec2/hipchat_notifier.py
+++ b/lambdas/ec2/hipchat_notifier.py
@@ -8,8 +8,10 @@ import os
 from urllib2 import Request, urlopen
 
 RED_ALERTS = [
-    'REAPER TERMINATION completed but bad tags found'
+    'The following instances have been stopped due to unparsable or missing termination_date tags'
     ]
+
+NO_ALERT = 'REAPER TERMINATION completed. The following instances have been deleted due to expired termination_date tags: []. The following instances have been stopped due to unparsable or missing termination_date tags: []'
 
 def get_account_alias():
     """
@@ -93,6 +95,8 @@ def post(event, context):
     for log_event in event_processed['logEvents']:
 
         message = log_event['message']
+        if NO_ALERT in message:
+            return "Success"
         headers = {
             "content-type": "application/json",
             "authorization": "Bearer %s" % V2TOKEN}

--- a/lambdas/ec2/reaper.py
+++ b/lambdas/ec2/reaper.py
@@ -80,6 +80,10 @@ def wait_for_tags(ec2_instance, wait_time):
         if termination_date:
             print("'termination_date' tag found!")
             return termination_date
+        instance_name = get_tag(ec2_instance, 'Name')
+        if instance_name != None:
+            if 'opsworks' in instance_name:
+                return instance_name
         lifetime = get_tag(ec2_instance, 'lifetime')
         if not lifetime:
             print("No 'lifetime' tag found; sleeping for 15s")
@@ -229,7 +233,9 @@ def enforce(event, context):
     instance = ec2.Instance(id=event['detail']['instance-id'])
     try:
         termination_date = wait_for_tags(instance, MINUTES_TO_WAIT)
-        if termination_date == INDEFINITE:
+        if 'opsworks' in termination_date:
+            return
+        elif termination_date == INDEFINITE:
             return
         elif termination_date:
             validate_ec2_termination_date(instance)
@@ -264,6 +270,9 @@ def terminate_expired_instances(event, context):
     print(instances)
     for instance in instances:
         ec2_termination_date = get_tag(instance, 'termination_date')
+        instance_name = get_tag(instance, 'Name')
+        if 'opsworks' in instance_name:
+            continue
         if ec2_termination_date is None:
             print("No termination date found for {0}".format(instance.id))
             stop_instance(instance, "EC2 instance has no termination_date")


### PR DESCRIPTION
Updated red alert message for hipchat notifier and added a variable to not send messages to the room if no instances were acted on, reducing messaging fatigue. 

Also added piece in wait_for_tags() that looks for instances with opsworks in the Name tag and tags them with the indefinite tag. This isn't something I plan to have long lived, but is a stopgap for people provisioning opsworks instances until we can either get AWS to copy termination_date tags over when they redeploy nodes, or come up with our own better solution. 

@tvpartytonight can you take a look for me and let me know what you think? I swear, this is the last update I plan to make for awhile. :smile: 