### PR TITLE
(TRAINTECH-8595) Enhance Puppet AWS reaper for classroom/SE demo environments

### DIFF
--- a/lambdas/ec2/reaper.py
+++ b/lambdas/ec2/reaper.py
@@ -697,6 +697,23 @@ def terminate_expired_v2_load_balancers():
         else:
             continue
 
+    if LIVEMODE:
+        if len(improperly_tagged) > 0 and len(deleted_load_balancers) < 1:
+            print(("REAPER TERMINATION completed. The following load balancers have been ignored due to unparsable or missing termination_date tags: {0}.").format(improperly_tagged))
+        elif len(deleted_load_balancers) > 0 and len(improperly_tagged) < 1:
+            print(("REAPER TERMINATION completed. The following load balancers have been deleted due to expired termination_date tags: {0}.").format(deleted_load_balancers))
+        else:
+            print(("REAPER TERMINATION completed. The following load balancers have been deleted due to expired termination_date tags: {0}. "
+                   "The following load balancers have been ignored due to unparsable or missing termination_date tags: {1}.").format(deleted_load_balancers, improperly_tagged))
+    else:
+        if len(improperly_tagged) > 0 and len(deleted_load_balancers) < 1:
+            print("REAPER TERMINATION completed. LIVEMODE is off, would have ignored the following load balancers due to unparsable or missing termination_date tags: {0} ".format(improperly_tagged))
+        elif len(deleted_load_balancers) > 0 and len(improperly_tagged) < 1:
+            print("REAPER TERMINATION completed. LIVEMODE is off, would have deleted the following load balancers: {0}. ".format(deleted_load_balancers))
+        else:
+            print(("REAPER TERMINATION completed. LIVEMODE is off, would have deleted the following load balancers: {0}. "
+                   "REAPER would have ignored the following load balancers due to unparsable or missing termination_date tags: {1}").format(deleted_load_balancers, improperly_tagged))
+
 def terminate_expired_instances():
     improperly_tagged = []
     deleted_instances = []

--- a/lambdas/ec2/reaper.py
+++ b/lambdas/ec2/reaper.py
@@ -285,20 +285,8 @@ def terminate_instance(ec2_instance, message):
         output += 'REAPER TERMINATION enabled: deleting instance {0}'.format(ec2_instance.id)
         print(output)
         ec2_instance.terminate()
-        waiter = ec2.get_waiter('instance_terminated')
-        waiter.wait(
-            Filters=[
-                {
-                    'Name': 'network-interface.attachment.status',
-                    'Values': [
-                        'detached',
-                    ]
-                },
-            ],
-            InstanceIds=[
-                ec2_instance.id,
-            ]
-        )
+        waiter = ec2.meta.client.get_waiter('instance_terminated')
+        waiter.wait(InstanceIds=[ec2_instance.id])
     else:
         output += "REAPER TERMINATION not enabled: LIVEMODE is {0}. Would have deleted instance {1}".format(LIVEMODE, ec2_instance.id)
         print(output)

--- a/lambdas/ec2/reaper.py
+++ b/lambdas/ec2/reaper.py
@@ -165,7 +165,7 @@ def delete_load_balancer(lb_arn, message):
     """
 
     # Get the target groups that will be deleted after the load balancer
-    target_groups = elbv2.describe_target_groups(lb_arn)
+    target_groups = elbv2.describe_target_groups(LoadBalancerArn=lb_arn)
 
     output = "REAPER TERMINATION: {1} for load balancer ARN={0}\n".format(lb_arn, message)
     if LIVEMODE:
@@ -176,7 +176,7 @@ def delete_load_balancer(lb_arn, message):
         output += "REAPER TERMINATION not enabled: LIVEMODE is {0}. Would have deleted load balancer {1}".format(LIVEMODE, lb_arn)
         print(output)
 
-    delete_target_groups(target_groups)
+    # delete_target_groups(target_groups)
 
 def terminate_instance(ec2_instance, message):
     """
@@ -335,7 +335,7 @@ def terminate_expired_load_balancers(event, context):
                     print("Load balancer {0} will be deleted {1} seconds from now, roughly".format(lb_arn, ttl.seconds))
                 else:
                     delete_load_balancer(lb_arn, "Load balancer {0} has expired".format(lb_arn))
-                    deleted_instances.append(lb_arn)
+                    deleted_load_balancers.append(lb_arn)
             except Exception as e:
                 print("Unable to parse the termination_date {1} for load balancer {0}".format(lb_arn, lb_termination_date))
                 continue

--- a/lambdas/ec2/slack_notifier.py
+++ b/lambdas/ec2/slack_notifier.py
@@ -17,7 +17,8 @@ NO_ALERT = [
     'REAPER TERMINATION completed. The following instances have been deleted due to expired termination_date tags: []. The following instances have been stopped due to unparsable or missing termination_date tags: [].'
     'REAPER TERMINATION completed. LIVEMODE is off, would have stopped the following instances due to unparsable or missing termination_date tags: []',
     'REAPER TERMINATION completed. LIVEMODE is off, would have deleted the following instances: []',
-    'REAPER TERMINATION completed. LIVEMODE is off, would have deleted the following instances: []. REAPER would have stopped the following instances due to unparsable or missing termination_date tags: []'
+    'REAPER TERMINATION completed. LIVEMODE is off, would have deleted the following instances: []. REAPER would have stopped the following instances due to unparsable or missing termination_date tags: []',
+    'REAPER TERMINATION completed. LIVEMODE is off, would have deleted the following load balancers: []. REAPER would have ignored the following load balancers due to unparsable or missing termination_date tags: []'
     ]
 
 def get_account_alias():


### PR DESCRIPTION
The ticket https://tickets.puppetlabs.com/browse/TRAINTECH-8595 describes the need for enhancing the AWS reaper to tear down additional resources provisioned by the classroom/SE demo infrastructure tooling.

This is very much "work in progress" code. An additional Lambda function entry point has been added for dev/test purposes now and will need to be integrated properly further down the road. To test this code, do the following:

```
git clone git@github.com:greglarkin/aws_resource_reaper.git
cd aws_resource_reaper
git checkout enhance-aws-reaper
export aws_region=us-west-2 # OPTIONAL: set to desired region
export aws_secret_access_key=CHANGEME
export aws_access_key=CHANGEME
docker run -e AWS_REGION=$aws_region -e AWS_ACCESS_KEY_ID=$aws_access_key -e AWS_SECRET_ACCESS_KEY=$aws_secret_access_key --rm -v "$PWD":/var/task lambci/lambda:python2.7 reaper.terminate_expired_resources
```

At the moment, I'm just starting the code to identify all of the resources (load balancers so far, target groups next, then Route 53 records and VPCs) that need to be deleted. I'm using similar patterns to what was already in place for terminating EC2 instances.