### PR TITLE
Update Lambda Python runtime and IAM policy

### DIFF
--- a/lambdas/ec2/README.md
+++ b/lambdas/ec2/README.md
@@ -205,5 +205,9 @@ terminated instances; it runs in its own Lambda, tied to the output of both the
 Schema Enforcer and Terminator looking for a "REAPER TERMINATION" string match in
 the output of the either Lambda. A Cloudwatch Log trigger with a filter pattern
 or `REAPER TERMINATION` should be attached to this Lambda, and a Slack channel webhook
-should be set as an environment variable. You will need to create a Slack app
-in your Slack workspace in order to create the webhook for each channel
+should be set as an environment variable. You will need to create a Slack workflow
+in each channel that should receive notifications. The variables to use are as follows:
+
+*account:* The account's alias according to AWS.
+*message:* The REAPER TERMINATION string, i.e. the log entry
+*region:* The AWS region the reaper's running in.

--- a/lambdas/ec2/README.md
+++ b/lambdas/ec2/README.md
@@ -208,6 +208,6 @@ or `REAPER TERMINATION` should be attached to this Lambda, and a Slack channel w
 should be set as an environment variable. You will need to create a Slack workflow
 in each channel that should receive notifications. The variables to use are as follows:
 
-*account:* The account's alias according to AWS.
-*message:* The REAPER TERMINATION string, i.e. the log entry
-*region:* The AWS region the reaper's running in.
+- *account:* The account's alias according to AWS.
+- *message:* The REAPER TERMINATION string, i.e. the log entry
+- *region:* The AWS region the reaper's running in.

--- a/lambdas/ec2/deploy_reaper.yaml
+++ b/lambdas/ec2/deploy_reaper.yaml
@@ -35,7 +35,8 @@ Resources:
                 - "sts:AssumeRole"
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AmazonEC2FullAccess
-        - arn:aws:iam::aws:policy/AWSLambdaFullAccess
+        - arn:aws:iam::aws:policy/AWSLambda_FullAccess
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
         - arn:aws:iam::aws:policy/IAMReadOnlyAccess
         - arn:aws:iam::aws:policy/CloudWatchActionsEC2Access
 

--- a/lambdas/ec2/deploy_reaper.yaml
+++ b/lambdas/ec2/deploy_reaper.yaml
@@ -51,7 +51,7 @@ Resources:
         Variables:
           LIVEMODE: !Ref LIVEMODE
       Timeout: 300
-      Runtime: python2.7
+      Runtime: python3.9
       Role: !GetAtt ReaperRole.Arn
     DependsOn: ReaperRole
 
@@ -85,7 +85,7 @@ Resources:
         Variables:
           LIVEMODE: !Ref LIVEMODE
       Timeout: 300
-      Runtime: python2.7
+      Runtime: python3.9
       Role: !GetAtt ReaperRole.Arn
     DependsOn: ReaperRole
 
@@ -141,7 +141,7 @@ Resources:
         S3Bucket: !Sub "${S3BucketPrefix}-${AWS::Region}"
       Handler: slack_notifier.post
       Timeout: 300
-      Runtime: python2.7
+      Runtime: python3.9
       Role: !GetAtt ReaperRole.Arn
       Environment:
         Variables:

--- a/lambdas/ec2/slack_notifier.py
+++ b/lambdas/ec2/slack_notifier.py
@@ -115,7 +115,6 @@ def post(event, context):
         request = Request(WEBHOOK, headers=headers, data=datastr)
         request.add_header('Content-Length', len(datastr))
         uopen = urlopen(request)
-        rawresponse = ''.join(uopen)
         uopen.close()
         assert uopen.code == 200
     return "Success"

--- a/lambdas/ec2/slack_notifier.py
+++ b/lambdas/ec2/slack_notifier.py
@@ -111,7 +111,9 @@ def post(event, context):
                     'text': message
                 }
             ]})
+        datastr = datastr.encode('utf-8')
         request = Request(WEBHOOK, headers=headers, data=datastr)
+        request.add_header('Content-Length', len(datastr))
         uopen = urlopen(request)
         rawresponse = ''.join(uopen)
         uopen.close()

--- a/lambdas/ec2/slack_notifier.py
+++ b/lambdas/ec2/slack_notifier.py
@@ -5,7 +5,7 @@ import ast
 import zlib
 import base64
 import os
-from urllib2 import Request, urlopen
+from urllib.request import Request, urlopen
 
 RED_ALERTS = [
     'The following instances have been stopped due to unparsable or missing termination_date tags:'

--- a/lambdas/ec2/slack_notifier.py
+++ b/lambdas/ec2/slack_notifier.py
@@ -53,7 +53,7 @@ def process_subscription_notification(event):
     """
     zipped = base64.standard_b64decode(event['awslogs']['data'])
     unzipped_string = zlib.decompress(zipped, 16+zlib.MAX_WBITS)
-    event_dict = ast.literal_eval(unzipped_string)
+    event_dict = ast.literal_eval(unzipped_string.decode('utf-8'))
     return event_dict
 
 def is_red_alert(message):


### PR DESCRIPTION
python2.7 is no longer supported so new installations cannot use it. Updated to 3.9.

Also replaced "AWSLambdaFullAccess" managed policy because it is deprecated. "AWSLambdaBasicExecutionRole" is now also required because it allows Lambdas to log to Cloudwatch Logs.