### PR TITLE
IAH-2025: Update runtime to Python 3.13

### DIFF
--- a/lambdas/ec2/deploy_reaper.yaml
+++ b/lambdas/ec2/deploy_reaper.yaml
@@ -51,7 +51,7 @@ Resources:
         Variables:
           LIVEMODE: !Ref LIVEMODE
       Timeout: 300
-      Runtime: python3.9
+      Runtime: python3.13
       Role: !GetAtt ReaperRole.Arn
     DependsOn: ReaperRole
 
@@ -85,7 +85,7 @@ Resources:
         Variables:
           LIVEMODE: !Ref LIVEMODE
       Timeout: 300
-      Runtime: python3.9
+      Runtime: python3.13
       Role: !GetAtt ReaperRole.Arn
     DependsOn: ReaperRole
 
@@ -141,7 +141,7 @@ Resources:
         S3Bucket: !Sub "${S3BucketPrefix}-${AWS::Region}"
       Handler: slack_notifier.post
       Timeout: 300
-      Runtime: python3.9
+      Runtime: python3.13
       Role: !GetAtt ReaperRole.Arn
       Environment:
         Variables:


### PR DESCRIPTION
3.9 is deprecated and will be removed early next year.