### PR TITLE
IAH-2358: Replace deprecated S3 bucket ACLs with bucket policies

### DIFF
--- a/lambdas/ec2/deploy_to_s3.yaml
+++ b/lambdas/ec2/deploy_to_s3.yaml
@@ -76,7 +76,7 @@ Resources:
           - Sid: ListBucket
             Effect: Allow
             Action: s3:ListBucket
-            Resource: !Ref S3Bucket
+            Resource: !Sub "arn:aws:s3:::${S3Bucket}"
             Principal: '*'
             Condition:
               StringEquals:
@@ -87,11 +87,7 @@ Resources:
               - s3:GetObject
               - s3:PutObject
               - s3:DeleteObject
-            Resource: !Join
-              - ''
-              - - 'arn:aws:s3:::'
-                - !Ref S3Bucket
-                - /*
+            Resource: !Sub "arn:aws:s3:::${S3Bucket}/*"
             Principal: '*'
             Condition:
               StringEquals:

--- a/lambdas/ec2/deploy_to_s3.yaml
+++ b/lambdas/ec2/deploy_to_s3.yaml
@@ -22,6 +22,11 @@ Parameters:
     Default: ec2-reaper
     Description: Prefix for the S3 Bucket Name in each region.
 
+  OrganizationID:
+    Type: String
+    Description: Provide your Organization ID to limit S3 access to accounts in the Organization.
+    AllowedPattern: ^o-[a-z0-9]+
+
 Resources:
   S3CopierRole:
     Properties:
@@ -60,7 +65,37 @@ Resources:
     Type: "AWS::S3::Bucket"
     Properties:
       BucketName: !Sub "${S3BucketPrefix}-${AWS::Region}"
-      AccessControl: PublicRead
+
+  S3Policy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref S3Bucket
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: ListBucket
+            Effect: Allow
+            Action: s3:ListBucket
+            Resource: !Ref S3Bucket
+            Principal: '*'
+            Condition:
+              StringEquals:
+                aws:PrincipalOrgID: !Ref OrganizationID
+          - Sid: CopyObjects
+            Effect: Allow
+            Action:
+              - s3:GetObject
+              - s3:PutObject
+              - s3:DeleteObject
+            Resource: !Join
+              - ''
+              - - 'arn:aws:s3:::'
+                - !Ref S3Bucket
+                - /*
+            Principal: '*'
+            Condition:
+              StringEquals:
+                aws:PrincipalOrgID: !Ref OrganizationID
 
   S3CopierLambda:
     Properties:

--- a/lambdas/ec2/deploy_to_s3.yaml
+++ b/lambdas/ec2/deploy_to_s3.yaml
@@ -107,77 +107,82 @@ Resources:
             import json
             import sys
             import traceback
-
-            try:
-                from urllib2 import HTTPError, build_opener, HTTPHandler, Request
-            except ImportError:
-                from urllib.error import HTTPError
-                from urllib.request import build_opener, HTTPHandler, Request
-
+            from urllib.error import HTTPError
+            from urllib.request import build_opener, HTTPHandler, Request
+            
             SUCCESS = "SUCCESS"
             FAILED = "FAILED"
+            
             s3 = boto3.resource('s3')
+            
             def handler(event, context):
-                print event
-                try:
-                    if event['RequestType'] == 'Delete':
-                        print('Deletion request received')
-                        bucket = s3.Bucket(event['ResourceProperties']['NewBucket'])
-                        bucket.objects.all().delete()
-                        send(event, context, SUCCESS)
-                        return
-                    copy_source = {'Bucket': event['ResourceProperties']['OrigBucketName'],
-                        'Key': event['ResourceProperties']['OrigReaperKey']}
-                    s3.meta.client.copy(copy_source,
-                        event['ResourceProperties']['NewBucket'],
-                        event['ResourceProperties']['OrigReaperKey'])
-                    s3.ObjectAcl(event['ResourceProperties']['NewBucket'],
-                        event['ResourceProperties']['OrigReaperKey']).put(ACL='public-read')
-                    slack_notifier_copy_source = {'Bucket': event['ResourceProperties']['OrigBucketName'],
-                        'Key': event['ResourceProperties']['OrigSlackNotifierKey']}
-                    s3.meta.client.copy(slack_notifier_copy_source,
-                        event['ResourceProperties']['NewBucket'],
-                        event['ResourceProperties']['OrigSlackNotifierKey'])
-                    s3.ObjectAcl(event['ResourceProperties']['NewBucket'],
-                        event['ResourceProperties']['OrigSlackNotifierKey']).put(ACL='public-read')
-                except Exception as e:
-                    print('Error copying S3 data')
-                    exc_type, exc_value, exc_traceback = sys.exc_info()
-                    traceback.print_exception(exc_type, exc_value, exc_traceback,
-                                              limit=2, file=sys.stdout)
-                    send(event, context, FAILED)
-                send(event, context, SUCCESS)
-
-            def send(event, context, response_status, reason=None, response_data=None, physical_resource_id=None):
-                response_data = response_data or {}
-                response_body = json.dumps(
-                    {
-                        'Status': response_status,
-                        'Reason': reason or "See the details in CloudWatch Log Stream: " + context.log_stream_name,
-                        'PhysicalResourceId': physical_resource_id or context.log_stream_name,
-                        'StackId': event['StackId'],
-                        'RequestId': event['RequestId'],
-                        'LogicalResourceId': event['LogicalResourceId'],
-                        'Data': response_data
-                    }
+              print(event)
+              try:
+                if event['RequestType'] == 'Delete':
+                  print('Deletion request received')
+                  bucket = s3.Bucket(event['ResourceProperties']['NewBucket'])
+                  bucket.objects.all().delete()
+                  send(event, context, SUCCESS)
+                  return
+            
+                copy_source = {
+                  'Bucket': event['ResourceProperties']['OrigBucketName'],
+                  'Key': event['ResourceProperties']['OrigReaperKey']
+                }
+                s3.meta.client.copy(
+                  copy_source,
+                  event['ResourceProperties']['NewBucket'],
+                  event['ResourceProperties']['OrigReaperKey']
                 )
-
-                opener = build_opener(HTTPHandler)
-                request = Request(event['ResponseURL'], data=response_body)
-                request.add_header('Content-Type', '')
-                request.add_header('Content-Length', len(response_body))
-                request.get_method = lambda: 'PUT'
-                try:
-                    response = opener.open(request)
-                    print("Status code: {}".format(response.getcode()))
-                    print("Status message: {}".format(response.msg))
-                    return True
-                except HTTPError as exc:
-                    print("Failed executing HTTP request: {}".format(exc.code))
-                    return False
+            
+                slack_notifier_copy_source = {
+                  'Bucket': event['ResourceProperties']['OrigBucketName'],
+                  'Key': event['ResourceProperties']['OrigSlackNotifierKey']
+                }
+                s3.meta.client.copy(
+                  slack_notifier_copy_source,
+                  event['ResourceProperties']['NewBucket'],
+                  event['ResourceProperties']['OrigSlackNotifierKey']
+                )
+            
+              except Exception as e:
+                print('Error copying S3 data')
+                exc_type, exc_value, exc_traceback = sys.exc_info()
+                traceback.print_exception(exc_type, exc_value, exc_traceback,
+                              limit=2, file=sys.stdout)
+                send(event, context, FAILED)
+            
+              send(event, context, SUCCESS)
+              
+            def send(event, context, response_status, reason=None, response_data=None, physical_resource_id=None):
+              response_data = response_data or {}
+              response_body = json.dumps({
+                'Status': response_status,
+                'Reason': reason or ("See the details in CloudWatch Log Stream: " + context.log_stream_name),
+                'PhysicalResourceId': physical_resource_id or context.log_stream_name,
+                'StackId': event['StackId'],
+                'RequestId': event['RequestId'],
+                'LogicalResourceId': event['LogicalResourceId'],
+                'Data': response_data
+              }).encode('utf-8')
+            
+              opener = build_opener(HTTPHandler)
+              request = Request(event['ResponseURL'], data=response_body)
+              request.add_header('Content-Type', '')
+              request.add_header('Content-Length', str(len(response_body)))
+              request.get_method = lambda: 'PUT'
+            
+              try:
+                response = opener.open(request)
+                print("Status code: {}".format(response.getcode()))
+                print("Status message: {}".format(response.msg))
+                return True
+              except HTTPError as exc:
+                print("Failed executing HTTP request: {}".format(exc.code))
+                return False
       Handler: index.handler
       Role: !GetAtt S3CopierRole.Arn
-      Runtime: python2.7
+      Runtime: python3.14
     Type: "AWS::Lambda::Function"
 
   S3CopierLambdaTrigger:


### PR DESCRIPTION
Newly created S3 buckets aren't able to use bucket ACLs. Instead, AWS enforces bucket policies. You can work around it, and legacy S3 buckets can keep their bucket ACLs, but AWS is pushing hard for IAM-style bucket policies these days. This pull request updates the lambda that creates S3 buckets in each region so that the new bucket uses a bucket policy which permits access to any other account that's in the same AWS Organization. It was either that or be forced to reference a list of accounts which could have access, and that'd require more manual upkeep than just querying the organization as needed.

It also brings the lambda's code & runtime from 2.7 to 3.13, which thankfully wasn't much of a lift in this case. urllib was the main thing I had to adjust for the 2 -> 3 conversion.